### PR TITLE
Update rake for CVE-2020-8130

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ doc/
 lib/bundler/man
 pkg
 rdoc
+rspec_junit.xml
 spec/reports
 test/tmp
 test/version_tmp

--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,3 @@
+--format RspecJunitFormatter
+--out rspec_junit.xml
+--format progress

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,29 @@
+#!/usr/bin/env groovy
+
+pipeline {
+  agent { label 'executor-v2' }
+
+  options {
+    timestamps()
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+  }
+
+  stages {
+    stage('Run Tests') {
+      steps {
+        sh './run-tests.sh'
+      }
+      post {
+        always {
+            junit 'rspec_junit.xml'
+        }
+      }
+    }
+  }
+
+  post {
+    always {
+      cleanupAndNotify(currentBuild.currentResult)
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Or install it yourself as:
     $ gem install sequel-postgres-schemata
 
 ## Usage
+
 ```ruby
 Sequel.extension :postgres_schemata
 
@@ -39,7 +40,14 @@ db.search_path = [:bar, :foo, :public]
 db.current_schemata # => [:bar, :public]
 db.rename_schema :bar, :foo
 db.current_schemata # => [:foo, :public]
+```
 
+## Running the Tests
+
+Install docker and docker-compose then run:
+
+```
+./run-tests.sh
 ```
 
 ## Contributing

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,20 @@
+---
+version: '3'
+services:
+  db:
+    image: "postgres:9.4"
+    environment:
+      - POSTGRES_PASSWORD=example
+
+  tests:
+    image: ruby:2.6
+    working_dir: /work
+    links:
+      - db
+    volumes:
+      - ./:/work
+    command: >
+      bash -c "
+        bundle install;
+        bundle exec rake spec
+      "

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -xeu
+
+docker-compose up \
+    --exit-code-from tests

--- a/sequel-postgres-schemata.gemspec
+++ b/sequel-postgres-schemata.gemspec
@@ -21,7 +21,8 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "sequel", "~> 4.3"
   
   spec.add_development_dependency "bundler", "~> 1.3"
-  spec.add_development_dependency "rake", "~> 10.1"
-  spec.add_development_dependency "rspec", "~> 2.14"
+  spec.add_development_dependency "rake", "~> 12.3.3"
+  spec.add_development_dependency "rspec", "~> 3.9"
   spec.add_development_dependency "pg", "~> 0.16"
+  spec.add_development_dependency 'rspec_junit_formatter', '~> 0.4.1'
 end

--- a/spec/schemata_spec.rb
+++ b/spec/schemata_spec.rb
@@ -2,20 +2,37 @@ require 'spec_helper'
 
 describe Sequel::Postgres::Schemata do
   
-  let(:db) { Sequel::connect adapter: 'postgres', search_path: %w(foo public) } 
-  let(:plain_db) { Sequel::connect adapter: 'postgres' }
+  let(:db) {
+    Sequel::connect(
+      adapter: 'postgres',
+      database: 'postgres',
+      search_path: %w(foo public),
+      host: 'db',
+      user: 'postgres',
+      password: 'example'
+    )
+  } 
+  let(:plain_db) {
+    Sequel::connect(
+      adapter: 'postgres',
+      database: 'postgres',
+      host: 'db',
+      user: 'postgres',
+      password: 'example'
+    )
+  }
 
   describe "#schemata" do
     it "lists all existing schematas" do
       schemata = db.schemata
-      schemata.should include(:public)
-      schemata.should_not include(:foo)
+      expect(schemata).to include(:public)
+      expect(schemata).to_not include(:foo)
     end
   end
   
   describe "#search_path" do
     it "returns the search path" do
-      db.search_path.should == %i(foo public)
+      expect(db.search_path).to eq(%i(foo public))
     end
 
     it "correctly handles the default list" do
@@ -25,9 +42,9 @@ describe Sequel::Postgres::Schemata do
     describe "with a block" do
       it "changes the search path temporarily" do
         db.search_path :bar do
-          db.search_path.should == %i(bar)
+          expect(db.search_path).to eq(%i(bar))
         end
-        db.search_path.should == %i(foo public)
+        expect(db.search_path).to eq(%i(foo public))
       end
 
       it "resets the search path when the given block raises an error" do
@@ -35,27 +52,27 @@ describe Sequel::Postgres::Schemata do
 
         begin
           db.search_path :bar do
-            db.search_path.should == %i(bar)
+            expect(db.search_path).to eq(%i(bar))
             raise MyContrivedError.new
           end
         rescue MyContrivedError
           # Gobble.
         end
-        db.search_path.should == %i(foo public)
+        expect(db.search_path).to eq(%i(foo public))
       end
 
       it "accepts symbols as arglist" do
         db.search_path :bar, :baz do
-          db.search_path.should == %i(bar baz)
+          expect(db.search_path).to eq(%i(bar baz))
         end
-        db.search_path.should == %i(foo public)
+        expect(db.search_path).to eq(%i(foo public))
       end
 
       it "allows prepending with prepend: true" do
         db.search_path :bar, prepend: true do
-          db.search_path.should == %i(bar foo public)
+          expect(db.search_path).to eq(%i(bar foo public))
         end
-        db.search_path.should == %i(foo public)
+        expect(db.search_path).to eq(%i(foo public))
       end
     end
   end
@@ -63,38 +80,38 @@ describe Sequel::Postgres::Schemata do
   describe "#search_path=" do
     it "accepts a single symbol" do
       db.search_path = :bar
-      db.search_path.should == %i(bar)
+      expect(db.search_path).to eq(%i(bar))
     end
     
     it "accepts a single string" do
       db.search_path = 'bar'
-      db.search_path.should == %i(bar)
+      expect(db.search_path).to eq(%i(bar))
     end
     
     it "accepts a formatted string" do
       db.search_path = 'bar, baz'
-      db.search_path.should == %i(bar baz)
+      expect(db.search_path).to eq(%i(bar baz))
     end
     
     it "accepts a symbol list" do
       db.search_path = %i(bar baz)
-      db.search_path.should == %i(bar baz)
+      expect(db.search_path).to eq(%i(bar baz))
     end
     
     it "accepts a string list" do
       db.search_path = %w(bar baz)
-      db.search_path.should == %i(bar baz)
+      expect(db.search_path).to eq(%i(bar baz))
     end
 
     it "quotes the string list correctly" do
       db.search_path = ["bar\" ',", "baz"]
-      db.search_path.should == [:"bar\" ',", :baz]
+      expect(db.search_path).to eq([:"bar\" ',", :baz])
     end
   end
   
   describe "#current_schemata" do
     it "returns the current schemata" do
-      db.current_schemata.should == %i(public)
+      expect(db.current_schemata).to eq(%i(public))
     end
   end
   
@@ -102,10 +119,10 @@ describe Sequel::Postgres::Schemata do
     it "renames a schema" do
       db.transaction rollback: :always do
         db.create_schema :test_schema
-        db.schemata.should include(:test_schema)
-        db.current_schemata.should == %i(public)
+        expect(db.schemata).to include(:test_schema)
+        expect(db.current_schemata).to eq(%i(public))
         db.rename_schema :test_schema, :foo
-        db.current_schemata.should == %i(foo public)
+        expect(db.current_schemata).to eq(%i(foo public))
       end
     end
   end


### PR DESCRIPTION
See nvd.nist.gov/vuln/detail/CVE-2020-8130 for details

* Update rspec-core to resolve error[1]
* Modify specs to use db name 'postgres' rather than relying on the default.
* Add Jenkins Pipeline
* Cleanup: Update rspec-core to avoid last_comment error
* Cleanup: Specify default 'postgres' database in specs
* Cleanup: Add instructions for running tests locally
* Cleanup: Transition to new rspec syntax

Related: conjurinc/ops#564

[1] stackoverflow.com/questions/35893584/nomethoderror-undefined-method-last-comment-after-upgrading-to-rake-11

Co-authored-by: John Tuttle <jtuttle@conjur.net>